### PR TITLE
added NoFocusOnAppearing to flags of window base class

### DIFF
--- a/TickTracker/Windows/BarWindowBase.cs
+++ b/TickTracker/Windows/BarWindowBase.cs
@@ -18,7 +18,8 @@ public abstract class BarWindowBase : Window
     protected WindowType WindowType { get; set; }
     protected const ImGuiWindowFlags DefaultFlags = ImGuiWindowFlags.NoScrollbar |
                                               ImGuiWindowFlags.NoTitleBar |
-                                              ImGuiWindowFlags.NoCollapse;
+                                              ImGuiWindowFlags.NoCollapse |
+                                              ImGuiWindowFlags.NoFocusOnAppearing;
 
     protected const ImGuiWindowFlags LockedBarFlags = ImGuiWindowFlags.NoBackground |
                                                     ImGuiWindowFlags.NoMove |


### PR DESCRIPTION
Currently the plugin steals focus from other windows when it appears. This is particularly apparent when they are set to appear when entering combat. In this case they would steal focus from other plugin windows like chat plugins.