### PR TITLE
Improve the semantics around physical DPS jobs

### DIFF
--- a/TickTracker/Configuration.cs
+++ b/TickTracker/Configuration.cs
@@ -22,7 +22,7 @@ public class Configuration : IPluginConfiguration
     public bool HideOnFullResource { get; set; } = false;
     public bool DisableCollisionInCombat { get; set; } = false;
     public bool CollisionDetection { get; set; } = false;
-    public bool HideMpBarOnMeleeRanged { get; set; } = false;
+    public bool HideMpBarOnPhysicalDPS { get; set; } = false;
 
     public Vector2 HPBarPosition { get; set; } = new(600, 500);
     public Vector2 HPBarSize { get; set; } = new(180, 50);

--- a/TickTracker/TickTracker.cs
+++ b/TickTracker/TickTracker.cs
@@ -50,10 +50,10 @@ public sealed class TickTracker : IDalamudPlugin
     /// </summary>
     private FrozenSet<uint> disabledHealthRegenSet = [];
 
-    private readonly FrozenSet<string> meleeAndRangedAbbreviations = Utilities.CreateFrozenSet(
+    private readonly FrozenSet<string> physicalDPSAbbreviations = Utilities.CreateFrozenSet(
         "PGL", "LNC", "ARC", "MNK", "DRG", "BRD", "ROG", "NIN", "MCH", "SAM", "DNC", "RPR", "VPR");
     private readonly FrozenSet<string> discipleOfTheLandAbbreviations = Utilities.CreateFrozenSet("MIN", "BTN", "FSH");
-    private FrozenSet<uint> meleeAndRangedDPS = [];
+    private FrozenSet<uint> physicalDPS = [];
     private FrozenSet<uint> discipleOfTheLand = [];
 
     // Function that triggers when client receives a network packet with an update for nearby actors
@@ -387,7 +387,7 @@ public sealed class TickTracker : IDalamudPlugin
         foreach (var row in jobSheet)
         {
             var name = row.Abbreviation.GetText();
-            if (meleeAndRangedAbbreviations.Contains(name))
+            if (physicalDPSAbbreviations.Contains(name))
             {
                 bag1.Add(row.RowId);
                 continue;
@@ -397,7 +397,7 @@ public sealed class TickTracker : IDalamudPlugin
                 bag2.Add(row.RowId);
             }
         }
-        meleeAndRangedDPS = bag1.ToFrozenSet();
+        physicalDPS = bag1.ToFrozenSet();
         discipleOfTheLand = bag2.ToFrozenSet();
         var bannedStatus = Utilities.CreateFrozenSet<uint>(135, 307, 751, 1419, 1465, 1730, 2326);
         var filteredSheet = statusSheet.Where(s => !bannedStatus.Contains(s.RowId));
@@ -492,7 +492,7 @@ public sealed class TickTracker : IDalamudPlugin
     private unsafe void UpdateBarState(IPlayerCharacter player)
     {
         var jobId = player.ClassJob.RowId;
-        var althideForMeleeRangedDPS = meleeAndRangedDPS.Contains(jobId);
+        var althideForPhysicalDPS = physicalDPS.Contains(jobId);
         var isDiscipleOfTheLand = discipleOfTheLand.Contains(jobId);
         var Enemy = player.TargetObject?.ObjectKind == Dalamud.Game.ClientState.Objects.Enums.ObjectKind.BattleNpc;
         var inCombat = condition[ConditionFlag.InCombat];
@@ -500,7 +500,7 @@ public sealed class TickTracker : IDalamudPlugin
         var hideForGPBar = isDiscipleOfTheLand && config.GPVisible;
 
         var shouldShowHPBar = ShowBar(inCombat, player.CurrentHp == player.MaxHp, Enemy) && !inDuelingArea;
-        var shouldShowMPBar = ShowBar(inCombat, player.CurrentMp == player.MaxMp, Enemy) && !inDuelingArea && !althideForMeleeRangedDPS;
+        var shouldShowMPBar = ShowBar(inCombat, player.CurrentMp == player.MaxMp, Enemy) && !inDuelingArea && !althideForPhysicalDPS;
         var shouldShowGPBar = isDiscipleOfTheLand && (!config.HideOnFullResource || player.CurrentGp != player.MaxGp) && !inDuelingArea;
 
         HPBarWindow.IsOpen = !config.LockBar || (shouldShowHPBar && config.HPVisible);

--- a/TickTracker/TickTracker.cs
+++ b/TickTracker/TickTracker.cs
@@ -492,7 +492,7 @@ public sealed class TickTracker : IDalamudPlugin
     private unsafe void UpdateBarState(IPlayerCharacter player)
     {
         var jobId = player.ClassJob.RowId;
-        var althideForPhysicalDPS = physicalDPS.Contains(jobId);
+        var althideForPhysicalDPS = config.HideMpBarOnPhysicalDPS && physicalDPS.Contains(jobId);
         var isDiscipleOfTheLand = discipleOfTheLand.Contains(jobId);
         var Enemy = player.TargetObject?.ObjectKind == Dalamud.Game.ClientState.Objects.Enums.ObjectKind.BattleNpc;
         var inCombat = condition[ConditionFlag.InCombat];

--- a/TickTracker/Windows/ConfigWindow.cs
+++ b/TickTracker/Windows/ConfigWindow.cs
@@ -107,6 +107,7 @@ public class ConfigWindow : Window
         }
         ImGui.Spacing();
         var disabled = !config.MPVisible;
+        var fullyDisabled = disabled & !config.MPNativeUiVisible;
 
         EditConfigProperty("Show MP Bar", config, c => c.MPVisible, (c, value) => c.MPVisible = value, checkbox: true);
         ImGui.BeginDisabled(nativeDisabled);
@@ -114,7 +115,7 @@ public class ConfigWindow : Window
         ImGui.SameLine();
         ImGuiComponents.HelpMarker("This will make the frame around the game's native MP Bar to fill up to represent the tick progress.");
         ImGui.EndDisabled();
-        ImGui.BeginDisabled(disabled);
+        ImGui.BeginDisabled(fullyDisabled);
         EditConfigProperty("Hide MP bar on Physical DPS", config, c => c.HideMpBarOnPhysicalDPS, (c, value) => c.HideMpBarOnPhysicalDPS = value, checkbox: true);
         ImGui.EndDisabled();
         ImGui.Spacing();
@@ -235,7 +236,7 @@ public class ConfigWindow : Window
     {
         if (disabled)
         {
-            ImGui.BeginDisabled();
+            ImGui.BeginDisabled(disabled);
         }
 
         EditConfigProperty("HP Bar Background Color", config, c => c.HPBarBackgroundColor, (c, value) => c.HPBarBackgroundColor = value, checkbox: false, button: false, colorEdit: true, flags);

--- a/TickTracker/Windows/ConfigWindow.cs
+++ b/TickTracker/Windows/ConfigWindow.cs
@@ -115,7 +115,7 @@ public class ConfigWindow : Window
         ImGuiComponents.HelpMarker("This will make the frame around the game's native MP Bar to fill up to represent the tick progress.");
         ImGui.EndDisabled();
         ImGui.BeginDisabled(disabled);
-        EditConfigProperty("Hide MP bar on melee and ranged DPS", config, c => c.HideMpBarOnMeleeRanged, (c, value) => c.HideMpBarOnMeleeRanged = value, checkbox: true);
+        EditConfigProperty("Hide MP bar on Physical DPS", config, c => c.HideMpBarOnPhysicalDPS, (c, value) => c.HideMpBarOnPhysicalDPS = value, checkbox: true);
         ImGui.EndDisabled();
         ImGui.Spacing();
 


### PR DESCRIPTION
- 62c9d954b971a913081b9a309fe4470a49c7daa0 renames some variables and strings:
        "melee or ranged DPS" is not quite accurate, it is "melee or physical ranged DPS", which can be simplified to just "physical DPS", so this change was made throughout

- eea8fc78bd3a2e830eec4838a3cc4cb73512812f corrects some logic errors around when to disable the MP bar and a certain checkbox:
  - if NativeUI is visible, then the checkbox labeled "Hide MP on physical DPS" (previously labeled "Hide MP on melee or ranged DPS") should be visible too, regardless of whether the ImGui MP bar is visible, so this is fixed
  - the MP bar (whether ImGui or NativeUI) should respect the "Hide MP on physical DPS" box (instead of ignoring it and always hiding for physical DPS jobs), so this is fixed

these were relatively minor annoyances but I finally found the time to help fix them, so, here we are